### PR TITLE
Improve error handling

### DIFF
--- a/git-dumper.py
+++ b/git-dumper.py
@@ -336,9 +336,7 @@ def fetch_git(url, directory, jobs, retry, timeout):
     if not verification[0]:
         printf(verification[1], url, "/.git/HEAD")
         return 1
-    elif not response.text.startswith('ref:'):
-        printf('error: %s/.git/HEAD is not a git HEAD file\n', url, file=sys.stderr)
-        return 1
+
 
     # check for directory listing
     printf('[-] Testing %s/.git/ ', url)

--- a/git-dumper.py
+++ b/git-dumper.py
@@ -8,6 +8,7 @@ import re
 import socket
 import subprocess
 import sys
+import traceback
 import urllib.parse
 import urllib3
 
@@ -105,7 +106,12 @@ class Worker(multiprocessing.Process):
             if task is None: # end signal
                 return
 
-            result = self.do_task(task, *self.args)
+            try:
+                result = self.do_task(task, *self.args)
+            except Exception as e:
+                print("Task %s raised exception:" % task)
+                traceback.print_exc()
+                result = []
 
             assert isinstance(result, list), 'do_task() should return a list of tasks'
 

--- a/git-dumper.py
+++ b/git-dumper.py
@@ -1,7 +1,6 @@
 #!/usr/bin/env python3
 from contextlib import closing
 import argparse
-import enum
 import multiprocessing
 import os
 import os.path


### PR DESCRIPTION
I added an exception handler to Worker.run so a single failed task doesn't crash the whole worker, and also added logic to check for HTML responses (error pages that give a 200 response code instead of 404) and zero-length responses (I've run into them, surprisingly).