### PR TITLE
fix: disabled urlib3 SSL warnings

### DIFF
--- a/git_dumper.py
+++ b/git_dumper.py
@@ -9,8 +9,10 @@ import socket
 import subprocess
 import sys
 import traceback
+
 import urllib.parse
 import urllib3
+urllib3.disable_warnings()
 
 import bs4
 import dulwich.index


### PR DESCRIPTION
Hello,

I've added the function urlib3.disable_warnings() to avoid the SSL warning message flood.

Best regards,
oppsec.