### PR TITLE
Fix for "AttributeError: 'Index' object has no attribute 'iterblobs' #27"

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
 PySocks
 requests
 beautifulsoup4
-dulwich
+dulwich==0.20.20


### PR DESCRIPTION
I fixed the version of dulwich on 0.20.20, this will fix the problem with "AttributeError: 'Index' object has no attribute 'iterblobs' #27"

#27 - Issue related with this