### PR TITLE
Fix unsupported dulwich Index.iterblobs method

### DIFF
--- a/git_dumper.py
+++ b/git_dumper.py
@@ -580,7 +580,7 @@ def fetch_git(url, directory, jobs, retry, timeout, http_headers):
     if os.path.exists(index_path):
         index = dulwich.index.Index(index_path)
 
-        for entry in index.iterblobs():
+        for entry in index.iterobjects():
             objs.add(entry[1].decode())
 
     # use packs to find more objects to fetch, and objects that are packed

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,6 +1,6 @@
 [metadata]
 name = git-dumper
-version = 1.0.5
+version = 1.0.6
 author = Maxime Arthaud
 author_email = maxime@arthaud.me
 license = MIT


### PR DESCRIPTION
`Index.iterblobs`  dropped on dulwich version 0.20.29 and occurs error