### PR TITLE
Fix invalid escape sequence warning in Python 3.13+

### DIFF
--- a/git_dumper.py
+++ b/git_dumper.py
@@ -406,7 +406,7 @@ def sanitize_file(filepath):
 
     with open(filepath, 'r+') as f:
         content = f.read()
-        modified_content = re.sub(UNSAFE, '# \g<0>', content, flags=re.IGNORECASE)
+        modified_content = re.sub(UNSAFE, r'# \g<0>', content, flags=re.IGNORECASE)
         if content != modified_content:
             printf("Warning: '%s' file was altered\n" % filepath)
             f.seek(0)


### PR DESCRIPTION
## Fix Python 3.13+ SyntaxWarning for invalid escape sequence

### Problem
Python 3.13+ generates a `SyntaxWarning` when running git-dumper:

```bash
git_dumper.py:409: SyntaxWarning: invalid escape sequence '\g'
modified_content = re.sub(UNSAFE, '# \g<0>', content, flags=re.IGNORECASE)
```

This occurs because Python has become stricter about unrecognized escape sequences in string literals. The `\g<0>` is intended as a regex replacement pattern (referring to the entire matched group), but Python interprets `\g` as an invalid escape sequence.

### Solution
Convert the replacement string to a raw string by adding the `r` prefix:

```python
# Before
modified_content = re.sub(UNSAFE, '# \g<0>', content, flags=re.IGNORECASE)
```
```python
# After  
modified_content = re.sub(UNSAFE, r'# \g<0>', content, flags=re.IGNORECASE)
```
### Impact
-   **Functionality**: No change - the regex replacement pattern works identically
-   **Compatibility**: Maintains backward compatibility with older Python versions
-   **User experience**: Eliminates the warning message that appears during execution

This is a minor but important fix for Python 3.13+ compatibility, ensuring clean execution without deprecation warnings.