### PR TITLE
fix: Python 3.10+ compatibility on Mac M1 (#35)

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
-PySocks
+PySocks>=1.7.1
 requests
 beautifulsoup4
 dulwich

--- a/setup.cfg
+++ b/setup.cfg
@@ -18,7 +18,7 @@ classifiers =
 py_modules = git_dumper
 python_requires = >=3.0
 install_requires =
-    PySocks
+    PySocks>=1.7.1
     requests
     beautifulsoup4
     dulwich

--- a/tests/test_imports.py
+++ b/tests/test_imports.py
@@ -1,0 +1,36 @@
+#!/usr/bin/env python3
+"""Test that imports work correctly on Python 3.10+"""
+import sys
+import unittest
+
+
+class TestImports(unittest.TestCase):
+    """Test module imports work on Python 3.10+"""
+
+    def test_socks_import_no_collections_error(self):
+        """Test that PySocks can be imported without collections.Callable error"""
+        try:
+            import socks
+            self.assertTrue(hasattr(socks, 'socksocket'))
+        except ImportError as e:
+            if 'Callable' in str(e) and 'collections' in str(e):
+                self.fail(f"PySocks has collections.Callable issue (needs PySocks>=1.7.1): {e}")
+            raise
+
+    def test_collections_abc_callable_available(self):
+        """Test that collections.abc.Callable is available (Python 3.3+)"""
+        from collections.abc import Callable
+        self.assertTrue(callable(Callable))
+
+    def test_python_version_compatibility(self):
+        """Verify we're testing on Python 3.0+"""
+        version_info = sys.version_info
+        self.assertGreaterEqual(
+            version_info.major * 10 + version_info.minor,
+            30,  # Python 3.0+
+            "Should work on Python 3.0+"
+        )
+
+
+if __name__ == '__main__':
+    unittest.main()


### PR DESCRIPTION
Fixes #35\n- Updated PySocks to fix collections.Callable import\n- Tested on Python 3.10-3.13\n- Mac M1 compatibility restored

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: Claude <noreply@anthropic.com>